### PR TITLE
Create tickets script: Update warning to suggest patience

### DIFF
--- a/bin/create_tickets.sh
+++ b/bin/create_tickets.sh
@@ -76,4 +76,4 @@ done
 
 echo "Finished generating Automated Tickets emails."
 
-echo "NOTE: It may take some time for Postfix to finish submitting them via the HTTP API. Force with sudo postqueue -f"
+echo "NOTE: It may take some time for Postfix to finish submitting them via the HTTP API. Please wait patiently; forcing via sudo postqueue -f may result in duplicate tickets."


### PR DESCRIPTION
The prior state seemed to suggest that forcing via `sudo postqueue -f` was acceptable, but this could potentially lead to ticket duplication.