### PR TITLE
rsyslog: Deploy fragment to "catch" log messages

### DIFF
--- a/bin/setup_dev_environment.sh
+++ b/bin/setup_dev_environment.sh
@@ -81,6 +81,18 @@ echo "* Cloning ${MAIN_PROJECT_GIT_REPO_URL} ..."
 git clone ${MAIN_PROJECT_GIT_REPO_URL} ||
     { echo "Failed to clone ${MAIN_PROJECT_GIT_REPO_URL}. Aborting!"; exit 1; }
 
+#
+# Deploy rsyslog config fragment to catch/redirect automated-tickets messages
+#
+
+echo "* Deploying rsyslog conf file for automated-tickets log messages ..."
+sudo cp -vf /tmp/${THIS_DEV_ENV_GIT_REPO_BASENAME}/etc/rsyslog.d/automated-tickets.conf /etc/rsyslog.d/ ||
+    { echo "Failed to deploy rsyslog conf file for automated-tickets log messages. Aborting!"; exit 1; }
+
+echo "* Restarting rsyslog to apply conf changes ..."
+sudo systemctl restart rsyslog ||
+    { echo "Failed to restart rsyslog to apply conf changes. Aborting!"; exit 1; }
+
 ######################################################
 # Setup upstream apt repos
 ######################################################

--- a/etc/rsyslog.d/automated-tickets.conf
+++ b/etc/rsyslog.d/automated-tickets.conf
@@ -1,0 +1,17 @@
+# https://github.com/WhyAskWhy/automated-tickets-dev
+
+# Purpose: Route log messages related to Automated Tickets to dedicated file
+
+# There are several properties/variables to look for the tag values:
+#
+# * $syslogtag (using 'contains')
+# * $programname (RFC3164 messages)
+# * $app-name (RFC5424 messages, pair with check for $programname)
+if $programname == 'automated-tickets'
+    or $app-name == 'automated-tickets' then {
+    action(type="omfile" file="/var/log/automated-tickets.log")
+
+    # Prevent duplicate logging of messages
+    # e.g., here and in /var/log/syslog too
+    stop
+}


### PR DESCRIPTION
Instead of watching /var/log/syslog for messages we can route to a dedicated file for tailing or later review.

Messages routed to that file are dropped from further routing in order to prevent duplication.